### PR TITLE
feat: light slider config, thermostat switch, publish entity states on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,19 @@ proflame2:
     icon: "mdi:fan"
     mode: slider
 
+  light:
+    name: "Light Level"
+    icon: "mdi:lightbulb"
+    mode: slider
+
   secondary_flame:
     name: "Secondary Flame"
     icon: "mdi:fire"
+
+  thermostat:
+    name: "Thermostat"
+    icon: "mdi:thermostat"
+    entity_category: config
 
   send:
     name: "Send Commands"
@@ -159,6 +169,7 @@ Once configured and running, the fireplace will appear in Home Assistant with:
 - `switch.fireplace_pilot_mode` - IPI/CPI mode selection
 - `switch.fireplace_aux_power` - Auxiliary outlet control
 - `switch.fireplace_secondary_flame` - Secondary (aka Front) Flame on/off
+- `switch.fireplace_thermostat` - Thermostat mode on/off
 - `number.fireplace_flame_height` - Flame height (0-6)
 - `number.fireplace_fan_speed` - Fan speed (0-6)
 - `number.fireplace_light_level` - Light brightness (0-6)

--- a/components/proflame2/__init__.py
+++ b/components/proflame2/__init__.py
@@ -28,6 +28,9 @@ ProFlame2AuxSwitch = proflame2_ns.class_(
 ProFlame2SecondaryFlameSwitch = proflame2_ns.class_(
     "ProFlame2SecondaryFlameSwitch", switch.Switch, cg.Component
 )
+ProFlame2ThermostatSwitch = proflame2_ns.class_(
+    "ProFlame2ThermostatSwitch", switch.Switch, cg.Component
+)
 
 # Number types
 ProFlame2FlameNumber = proflame2_ns.class_(
@@ -50,6 +53,7 @@ CONF_POWER = "power"
 CONF_PILOT = "pilot"
 CONF_AUX = "aux"
 CONF_SECONDARY_FLAME = "secondary_flame"
+CONF_THERMOSTAT = "thermostat"
 CONF_FLAME = "flame"
 CONF_FAN = "fan"
 CONF_LIGHT = "light"
@@ -68,6 +72,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_PILOT): switch.switch_schema(ProFlame2PilotSwitch),
         cv.Optional(CONF_AUX): switch.switch_schema(ProFlame2AuxSwitch),
         cv.Optional(CONF_SECONDARY_FLAME): switch.switch_schema(ProFlame2SecondaryFlameSwitch),
+        cv.Optional(CONF_THERMOSTAT): switch.switch_schema(ProFlame2ThermostatSwitch),
         cv.Optional(CONF_FLAME): number.number_schema(ProFlame2FlameNumber),
         cv.Optional(CONF_FAN): number.number_schema(ProFlame2FanNumber),
         cv.Optional(CONF_LIGHT): number.number_schema(ProFlame2LightNumber),
@@ -124,6 +129,15 @@ async def to_code(config):
         await switch.register_switch(sw, conf)
         cg.add(sw.set_parent(var))
         cg.add(var.set_secondary_flame_switch(sw))
+
+    # Configure thermostat switch
+    if CONF_THERMOSTAT in config:
+        conf = config[CONF_THERMOSTAT]
+        sw = cg.new_Pvariable(conf[CONF_ID])
+        await cg.register_component(sw, conf)
+        await switch.register_switch(sw, conf)
+        cg.add(sw.set_parent(var))
+        cg.add(var.set_thermostat_switch(sw))
 
     # Configure flame number
     if CONF_FLAME in config:

--- a/components/proflame2/manifest.json
+++ b/components/proflame2/manifest.json
@@ -5,7 +5,7 @@
   "dependencies": ["spi", "switch", "number", "button"],
   "codeowners": ["@marksieczkowski","@j2deen"],
   "requirements": [],
-  "version": "3.0.2",
+  "version": "3.1.0",
   "author": "Mark Sieczkowski, Jay Deen",
   "license": "MIT",
   "description": "Control ProFlame 2 fireplace systems using ESP32 and CC1101 RF module",
@@ -19,6 +19,7 @@
     "Fan speed control (0-6 levels)",
     "Light level control (0-6 levels)",
     "Secondary flame control",
+    "Thermostat mode control",
     "IPI/CPI pilot mode selection",
     "Auxiliary power control",
     "Home Assistant integration",
@@ -37,6 +38,7 @@
     "fan": "optional",
     "light": "optional",
     "secondary_flame": "optional",
+    "thermostat": "optional",
     "send": "optional"
   }
 }

--- a/components/proflame2/proflame2_cc1101.cpp
+++ b/components/proflame2/proflame2_cc1101.cpp
@@ -72,6 +72,34 @@ void ProFlame2Component::setup() {
       .aux_power = false,
       .flame_level = 0};
 
+  // Publish initial states so HA shows 0/off after a reboot instead of
+  // "unknown". The RF link is one-way, so the fireplace's real state can't
+  // be read back; report what current_state_ would transmit.
+  if (this->power_switch_) {
+    this->power_switch_->publish_state(false);
+  }
+  if (this->pilot_switch_) {
+    this->pilot_switch_->publish_state(false);
+  }
+  if (this->aux_switch_) {
+    this->aux_switch_->publish_state(false);
+  }
+  if (this->secondary_flame_switch_) {
+    this->secondary_flame_switch_->publish_state(false);
+  }
+  if (this->thermostat_switch_) {
+    this->thermostat_switch_->publish_state(false);
+  }
+  if (this->flame_number_) {
+    this->flame_number_->publish_state(0);
+  }
+  if (this->fan_number_) {
+    this->fan_number_->publish_state(0);
+  }
+  if (this->light_number_) {
+    this->light_number_->publish_state(0);
+  }
+
   ESP_LOGCONFIG(TAG, "ProFlame 2 setup complete");
 }
 

--- a/components/proflame2/proflame2_cc1101.h
+++ b/components/proflame2/proflame2_cc1101.h
@@ -280,6 +280,17 @@ class ProFlame2SecondaryFlameSwitch : public switch_::Switch, public Component {
   ProFlame2Component *parent_;
 };
 
+class ProFlame2ThermostatSwitch : public switch_::Switch, public Component {
+ public:
+  void set_parent(ProFlame2Component *parent) { this->parent_ = parent; }
+  void write_state(bool state) override {
+    this->parent_->set_thermostat(state);
+  }
+
+ protected:
+  ProFlame2Component *parent_;
+};
+
 class ProFlame2SendButton : public button::Button, public Component {
  public:
   void set_parent(ProFlame2Component *parent) { this->parent_ = parent; }

--- a/proflame2_fireplace.yaml
+++ b/proflame2_fireplace.yaml
@@ -79,9 +79,19 @@ proflame2:
     icon: "mdi:fan"
     mode: slider
 
+  light:
+    name: "Light Level"
+    icon: "mdi:lightbulb"
+    mode: slider
+
   secondary_flame:
     name: "Secondary Flame"
     icon: "mdi:fire"
+
+  thermostat:
+    name: "Thermostat"
+    icon: "mdi:thermostat"
+    entity_category: config
 
   send:
     name: "Send Commands"

--- a/test_compile.yaml
+++ b/test_compile.yaml
@@ -38,6 +38,8 @@ proflame2:
     name: "Aux Power"
   secondary_flame:
     name: "Secondary Flame"
+  thermostat:
+    name: "Thermostat"
   flame:
     name: "Flame Height"
     mode: slider


### PR DESCRIPTION
## Summary

PR 2 of 2 from the component review (PR 1 was #11 / v3.0.2). Targets v3.1.0.

### Entity states published on boot
Entities only published state when a value changed, so after an ESP reboot every slider and switch showed **"unknown"** in HA until touched. `setup()` now publishes the initial state (off/0) for every configured entity, matching the zero-initialized `current_state_`.

Note: the RF link is one-way, so after a reboot HA shows off/0 even if the fireplace is physically running — that's what the component would transmit on the next Send, reported honestly.

### Thermostat switch exposed
The C++ side fully supported a thermostat switch (`set_thermostat()`, cmd1 bit `0x02`) but it was never wired into the Python schema, making it unconfigurable. Added `ProFlame2ThermostatSwitch` and the `thermostat:` config key.

### Light slider in configs
The light number entity already existed in the component but wasn't in the example YAML. Added `light:` (plus the new `thermostat:`) to `proflame2_fireplace.yaml`, README, and `test_compile.yaml`.

### Manifest
Bumped to `3.1.0`; thermostat added to `config_schema` and `features`.

## Testing
- `esphome compile test_compile.yaml` succeeds (latest `ghcr.io/esphome/esphome`, ESP-IDF 5.5.4) with no component warnings — now covering all 9 entities including thermostat.
- Hardware check before relying on it: real-remote captures had `thermostat=true`, so after flashing, set the new Thermostat switch to match the fireplace's actual mode before the first Send.
- No TX/protocol changes; all controls keep the explicit Send-button pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)